### PR TITLE
Proposed update to the extend-coo-nd branch

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -65,6 +65,7 @@ class _spbase:
 
     __array_priority__ = 10.1
     _format = 'und'  # undefined
+    _allow_nd = (2,)
 
     @property
     def ndim(self) -> int:
@@ -157,9 +158,8 @@ class _spbase:
         """
         # If the shape already matches, don't bother doing an actual reshape
         # Otherwise, the default is to convert to COO and use its reshape
-        is_array = isinstance(self, sparray)
-        allowed_ndims = (1,2) if is_array else (2,)
-        shape = check_shape(args, self.shape, allowed_ndims=allowed_ndims)
+        # Don't restrict ndim on this first call. That happens in constructor
+        shape = check_shape(args, self.shape, allow_nd=range(1, 65))
         order, copy = check_reshape_kwargs(kwargs)
         if shape == self.shape:
             if copy:

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -27,8 +27,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
         _data_matrix.__init__(self, arg1, maxprint=maxprint)
-        is_array = isinstance(self, sparray)
-        allowed_ndims = (1,2) if is_array else (2,)
 
         if issparse(arg1):
             if arg1.format == self.format and copy:
@@ -40,10 +38,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             )
 
         elif isinstance(arg1, tuple):
-            if isshape(arg1, allowed_ndims=allowed_ndims):
+            if isshape(arg1, allow_nd=self._allow_nd):
                 # It's a tuple of matrix dimensions (M, N)
                 # create empty matrix
-                self._shape = check_shape(arg1, allowed_ndims=allowed_ndims)
+                self._shape = check_shape(arg1, allow_nd=self._allow_nd)
                 M, N = self._swap(self._shape_as_2d)
                 # Select index dtype large enough to pass array and
                 # scalar parameters to sparsetools
@@ -88,26 +86,24 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise ValueError(f"unrecognized {self.__class__.__name__} "
                                  f"constructor input: {arg1}") from e
             if isinstance(self, sparray) and arg1.ndim < 2 and self.format == "csc":
-                raise ValueError(
-                    f"CSC arrays don't support {arg1.ndim}D input. Use 2D"
-                )
+                raise ValueError(f"CSC arrays don't support {arg1.ndim}D input. Use 2D")
             coo = self._coo_container(arg1, dtype=dtype)
             arrays = coo._coo_to_compressed(self._swap)
             self.indptr, self.indices, self.data, self._shape = arrays
 
         # Read matrix dimensions given, if any
         if shape is not None:
-            self._shape = check_shape(shape, allowed_ndims=allowed_ndims)
+            self._shape = check_shape(shape, allow_nd=self._allow_nd)
         elif self.shape is None:
             # shape not already set, try to infer dimensions
             try:
-                major_d = len(self.indptr) - 1
-                minor_d = self.indices.max() + 1
+                M = len(self.indptr) - 1
+                N = self.indices.max() + 1
             except Exception as e:
                 raise ValueError('unable to infer matrix dimensions') from e
 
-            self._shape = check_shape(self._swap((major_d, minor_d)),
-                                      allowed_ndims=allowed_ndims)
+            self._shape = check_shape(self._swap((M, N)), allow_nd=self._allow_nd)
+            self._shape = check_shape(self._swap((M, N)), allow_nd=self._allow_nd)
 
         if dtype is not None:
             newdtype = getdtype(dtype)
@@ -1290,8 +1286,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         self.data = _prune_array(self.data[:self.nnz])
 
     def resize(self, *shape):
-        allowed_ndims = (1,2) if isinstance(self, sparray) else (2,)
-        shape = check_shape(shape, allowed_ndims=allowed_ndims)
+        shape = check_shape(shape, allow_nd=self._allow_nd)
 
         if hasattr(self, 'blocksize'):
             bm, bn = self.blocksize

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -24,17 +24,16 @@ import operator
 
 class _coo_base(_data_matrix, _minmax_mixin):
     _format = 'coo'
+    _allow_nd = range(1,65)
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
         _data_matrix.__init__(self, arg1, maxprint=maxprint)
-        is_array = isinstance(self, sparray)
-        allowed_ndims = range(1,65) if is_array else (2,)
         if not copy:
             copy = copy_if_needed
 
         if isinstance(arg1, tuple):
-            if isshape(arg1, allowed_ndims=allowed_ndims):
-                self._shape = check_shape(arg1, allowed_ndims=allowed_ndims)
+            if isshape(arg1, allow_nd=self._allow_nd):
+                self._shape = check_shape(arg1, allow_nd=self._allow_nd)
                 idx_dtype = self._get_index_dtype(maxval=max(self._shape))
                 data_dtype = getdtype(dtype, default=float)
                 self.coords = tuple(np.array([], dtype=idx_dtype)
@@ -53,7 +52,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
                                          'sized index arrays')
                     shape = tuple(operator.index(np.max(idx)) + 1
                                   for idx in coords)
-                self._shape = check_shape(shape, allowed_ndims=allowed_ndims)
+                self._shape = check_shape(shape, allow_nd=self._allow_nd)
                 idx_dtype = self._get_index_dtype(coords,
                                                   maxval=max(self.shape),
                                                   check_contents=True)
@@ -66,25 +65,25 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 if arg1.format == self.format and copy:
                     self.coords = tuple(idx.copy() for idx in arg1.coords)
                     self.data = arg1.data.copy()
-                    self._shape = check_shape(arg1.shape, allowed_ndims=allowed_ndims)
+                    self._shape = check_shape(arg1.shape, allow_nd=self._allow_nd)
                     self.has_canonical_format = arg1.has_canonical_format
                 else:
                     coo = arg1.tocoo()
                     self.coords = tuple(coo.coords)
                     self.data = coo.data
-                    self._shape = check_shape(coo.shape, allowed_ndims=allowed_ndims)
+                    self._shape = check_shape(coo.shape, allow_nd=self._allow_nd)
                     self.has_canonical_format = False
             else:
                 # dense argument
                 M = np.asarray(arg1)
-                if not is_array:
+                if not isinstance(self, sparray):
                     M = np.atleast_2d(M)
                     if M.ndim != 2:
                         raise TypeError(f'expected 2D array or matrix, not {M.ndim}D')
 
-                self._shape = check_shape(M.shape, allowed_ndims=allowed_ndims)
+                self._shape = check_shape(M.shape, allow_nd=self._allow_nd)
                 if shape is not None:
-                    if check_shape(shape, allowed_ndims=allowed_ndims) != self._shape:
+                    if check_shape(shape, allow_nd=self._allow_nd) != self._shape:
                         message = f'inconsistent shapes: {shape} != {self._shape}'
                         raise ValueError(message)
 
@@ -130,9 +129,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         self.coords = self.coords[:-1] + (new_col,)
 
     def reshape(self, *args, **kwargs):
-        is_array = isinstance(self, sparray)
-        allowed_ndims = range(1,65) if is_array else (2,)
-        shape = check_shape(args, self.shape, allowed_ndims=allowed_ndims)
+        shape = check_shape(args, self.shape, allow_nd=self._allow_nd)
         order, copy = check_reshape_kwargs(kwargs)
 
         # Return early if reshape is not required
@@ -248,9 +245,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
     transpose.__doc__ = _spbase.transpose.__doc__
 
     def resize(self, *shape) -> None:
-        is_array = isinstance(self, sparray)
-        allowed_ndims = (1,2) if is_array else (2,)
-        shape = check_shape(shape, allowed_ndims=allowed_ndims)
+        shape = check_shape(shape, allow_nd=self._allow_nd)
 
         # Check for added dimensions.
         if len(shape) > self.ndim:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -181,7 +181,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             axis += self.ndim
         if axis >= self.ndim:
             raise ValueError('axis out of bounds')
-        
+
         return np.bincount(downcast_intp_index(self.coords[1 - axis]),
                            minlength=self.shape[1 - axis])
 
@@ -591,7 +591,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             coo_todense_nd(strides, self.nnz, self.ndim,
                            coords, self.data, result.ravel('A'), fortran)
         return self._container(result, copy=False)
-    
+
 
     def _add_sparse(self, other):
         if self.ndim < 3:
@@ -602,10 +602,10 @@ class _coo_base(_data_matrix, _minmax_mixin):
         other = self.__class__(other)
         new_data = np.concatenate((self.data, other.data))
         new_coords = tuple(np.concatenate((self.coords, other.coords), axis=1))
-        A = self.__class__((new_data, new_coords), shape=self.shape)         
+        A = self.__class__((new_data, new_coords), shape=self.shape)
         return A
 
-    
+
     def _sub_sparse(self, other):
         if self.ndim < 3:
             return self.tocsr()._sub_sparse(other)
@@ -617,7 +617,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         new_coords = tuple(np.concatenate((self.coords, other.coords), axis=1))
         A = coo_array((new_data, new_coords), shape=self.shape)
         return A
-    
+
 
     def _matmul_vector(self, other):
         if self.ndim > 2:
@@ -628,10 +628,10 @@ class _coo_base(_data_matrix, _minmax_mixin):
             coords = np.concatenate(self.coords)
             coo_matvec_nd(self.nnz, len(self.shape), strides, coords, self.data,
                           other, result)
-            
+
             result = result.reshape(self.shape[:-1])
             return result
-        
+
         # self.ndim <= 2
         result_shape = self.shape[0] if self.ndim > 1 else 1
         result = np.zeros(result_shape,
@@ -656,7 +656,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
     def _matmul_dispatch(self, other):
         if self.ndim < 3:
             return _spbase._matmul_dispatch(self, other)
-        
+
         N = self.shape[-1]
         err_prefix = "matmul: dimension mismatch with signature"
         if other.__class__ is np.ndarray:
@@ -670,14 +670,14 @@ class _coo_base(_data_matrix, _minmax_mixin):
                 raise ValueError(msg)
             msg = "n-D matrix-matrix multiplication not implemented for ndim>2"
             raise NotImplementedError(msg)
-        
+
         if isscalarlike(other):
             # scalar value
             return self._mul_scalar(other)
-        
+
         if issparse(other):
             raise NotImplementedError("sparse-sparse matmul not implemented for ndim>2")
-        
+
         # If it's a list or whatever, treat it like an array
         other_a = np.asanyarray(other)
 
@@ -727,12 +727,12 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             raise NotImplementedError(
                 f"coo_matmat_dense not implemented for ndim={self.ndim}")
-  
+
         result = np.zeros(result_shape, dtype=result_dtype)
         coo_matmat_dense(self.nnz, other.shape[-1], row, col,
                          self.data, other.ravel('C'), result)
         return result.view(type=type(other))
-    
+
 
 def _ravel_coords(coords, shape, order='C'):
     """Like np.ravel_multi_index, but avoids some overflow issues."""

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -246,7 +246,10 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     def resize(self, *shape) -> None:
         shape = check_shape(shape, allow_nd=self._allow_nd)
-
+        if self.ndim > 2:
+            raise ValueError("only 1-D or 2-D input accepted")
+        if len(shape) > 2:
+            raise ValueError("shape argument must be 1-D or 2-D")
         # Check for added dimensions.
         if len(shape) > self.ndim:
             flat_coords = _ravel_coords(self.coords, self.shape)

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -17,6 +17,7 @@ from ._compressed import _cs_matrix
 
 class _csr_base(_cs_matrix):
     _format = 'csr'
+    _allow_nd = (1, 2)
 
     def transpose(self, axes=None, copy=False):
         if axes is not None and axes != (1, 0):

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -17,14 +17,13 @@ from ._sputils import (isdense, getdtype, isshape, isintlike, isscalarlike,
 
 class _dok_base(_spbase, IndexMixin, dict):
     _format = 'dok'
+    _allow_nd = (1, 2)
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
         _spbase.__init__(self, arg1, maxprint=maxprint)
 
-        is_array = isinstance(self, sparray)
-        allowed_ndims = (1,2) if is_array else (2,)
-        if isinstance(arg1, tuple) and isshape(arg1, allowed_ndims=allowed_ndims):
-            self._shape = check_shape(arg1, allowed_ndims=allowed_ndims)
+        if isinstance(arg1, tuple) and isshape(arg1, allow_nd=self._allow_nd):
+            self._shape = check_shape(arg1, allow_nd=self._allow_nd)
             self._dict = {}
             self.dtype = getdtype(dtype, default=float)
         elif issparse(arg1):  # Sparse ctor
@@ -37,7 +36,7 @@ class _dok_base(_spbase, IndexMixin, dict):
                 arg1 = arg1.astype(dtype, copy=False)
 
             self._dict = arg1._dict
-            self._shape = check_shape(arg1.shape, allowed_ndims=allowed_ndims)
+            self._shape = check_shape(arg1.shape, allow_nd=self._allow_nd)
             self.dtype = getdtype(arg1.dtype)
         else:  # Dense ctor
             try:
@@ -57,7 +56,7 @@ class _dok_base(_spbase, IndexMixin, dict):
                 d = self._coo_container(arg1, shape=shape, dtype=dtype).todok()
                 self._dict = d._dict
                 self.dtype = getdtype(d.dtype)
-            self._shape = check_shape(arg1.shape, allowed_ndims=allowed_ndims)
+            self._shape = check_shape(arg1.shape, allow_nd=self._allow_nd)
 
     def update(self, val):
         # Prevent direct usage of update
@@ -492,9 +491,7 @@ class _dok_base(_spbase, IndexMixin, dict):
     tocsc.__doc__ = _spbase.tocsc.__doc__
 
     def resize(self, *shape):
-        is_array = isinstance(self, sparray)
-        allowed_ndims = (1,2) if is_array else (2,)
-        shape = check_shape(shape, allowed_ndims=allowed_ndims)
+        shape = check_shape(shape, allow_nd=self._allow_nd)
         if len(shape) != len(self.shape):
             # TODO implement resize across dimensions
             raise NotImplementedError

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -129,7 +129,7 @@ def triu(A, k=0, format=None):
 
     Returns
     -------
-    L : sparse array or matrix 
+    L : sparse array or matrix
         Upper triangular portion of A in sparse format.
         Sparse array if A is a sparse array, otherwise matrix.
 

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -3,6 +3,7 @@ class spmatrix:
 
     It cannot be instantiated.  Most of the work is provided by subclasses.
     """
+    _allow_nd = (2,)
 
     @property
     def _bsr_container(self):

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -241,17 +241,14 @@ def isintlike(x) -> bool:
     return True
 
 
-def isshape(x, nonneg=False, *, allowed_ndims=(2,)) -> bool:
+def isshape(x, nonneg=False, *, allow_nd=(2,)) -> bool:
     """Is x a valid tuple of dimensions?
 
     If nonneg, also checks that the dimensions are non-negative.
-    If allowed_ndims is provided, shapes of lengths belonging in
-    allowed_ndims are allowed.
-    If allowed_ndims is not provided, only shapes of length 2 are
-    allowed.
+    Shapes of length in the tuple allow_nd are allowed.
     """
     ndim = len(x)
-    if ndim not in allowed_ndims:
+    if ndim not in allow_nd:
         return False
 
     for d in x:
@@ -301,7 +298,7 @@ def validateaxis(axis) -> None:
         raise ValueError("axis out of range")
 
 
-def check_shape(args, current_shape=None, *, allowed_ndims=(2,)):
+def check_shape(args, current_shape=None, *, allow_nd=(2,)) -> tuple[int, ...]:
     """Imitate numpy.matrix handling of shape arguments
 
     Parameters
@@ -311,12 +308,8 @@ def check_shape(args, current_shape=None, *, allowed_ndims=(2,)):
     current_shape : tuple, optional
         The current shape of the sparse array or matrix.
         If None (default), the current shape will be inferred from args.
-    allowed_ndims : tuple, optional
-        Tuple representing the set of valid dimensionalities.
-        If (1,2), then only 1-D or 2-D arrays are accepted.
-        If (2,), then only 2-D arrays are accepted.
-        Otherwise, n-D arrays are accepted.
-        Defaults to (2,).
+    allow_nd : tuple of ints, optional default: (2,)
+        If shape does not have a length in the tuple allow_nd an error is raised.
 
     Returns
     -------
@@ -324,8 +317,7 @@ def check_shape(args, current_shape=None, *, allowed_ndims=(2,)):
         The new shape after validation.
     """
     if len(args) == 0:
-        raise TypeError("function missing 1 required positional argument: "
-                        "'shape'")
+        raise TypeError("function missing 1 required positional argument: 'shape'")
     if len(args) == 1:
         try:
             shape_iter = iter(args[0])
@@ -337,12 +329,8 @@ def check_shape(args, current_shape=None, *, allowed_ndims=(2,)):
         new_shape = tuple(operator.index(arg) for arg in args)
 
     if current_shape is None:
-        ndim = len(new_shape)
-        if allowed_ndims == (2,) and ndim != 2:
-            raise ValueError('shape must be a 2-tuple of positive integers')
-        if allowed_ndims == (1,2) and ndim > 2:
-            raise ValueError('shape must be a 1- or 2-tuple of positive integers')
-
+        if len(new_shape) not in allow_nd:
+            raise ValueError(f'shape must have length in {allow_nd}. Got {new_shape=}')
         if any(d < 0 for d in new_shape):
             raise ValueError("'shape' elements cannot be negative")
     else:
@@ -368,12 +356,8 @@ def check_shape(args, current_shape=None, *, allowed_ndims=(2,)):
         else:
             raise ValueError('can only specify one unknown dimension')
 
-    ndim_new = len(new_shape)
-    if allowed_ndims == (2,) and ndim_new != 2:
-        raise ValueError('shape must be two-dimensional')
-
-    if ndim_new >= 3 and allowed_ndims == (1,2):
-        raise ValueError('shape must be one- or two-dimensional')
+    if len(new_shape) not in allow_nd:
+        raise ValueError(f'shape must have length in {allow_nd}. Got {new_shape=}')
 
     return new_shape
 

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -253,7 +253,7 @@ def isshape(x, nonneg=False, *, allowed_ndims=(2,)) -> bool:
     ndim = len(x)
     if ndim not in allowed_ndims:
         return False
-    
+
     for d in x:
         if not isintlike(d):
             return False

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1732,10 +1732,10 @@ class _TestCommon:
         class Custom:
             def __init__(self, scalar):
                 self.scalar = scalar
-                
+
             def __rmul__(self, other):
                 return other * self.scalar
-        
+
         scalar = 2
         A = self.spcreator([[1],[2],[3]])
         c = Custom(scalar)
@@ -4689,7 +4689,7 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         expected = m.toarray()
         assert_array_equal(m.tocsc().toarray(), expected)
         assert_array_equal(m.tocsr().toarray(), expected)
-    
+
     def test_tocoo_gh10050(self):
         # regression test for gh-10050
         m = dia_matrix([[1, 2], [3, 4]]).tocoo()

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -55,7 +55,7 @@ class TestConstructUtils:
             )
         ):
             cls(0)
-    
+
     @pytest.mark.parametrize("cls", [
         csc_matrix, csr_matrix, coo_matrix,
         bsr_matrix, dia_matrix, lil_matrix
@@ -796,7 +796,7 @@ class TestConstructUtils:
     def test_random_array_maintains_array_shape(self):
         arr = construct.random_array((0, 4), density=0.3, dtype=int)
         assert arr.shape == (0, 4)
-        
+
         arr = construct.random_array((10, 10, 10), density=0.3, dtype=int)
         assert arr.shape == (10, 10, 10)
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -142,11 +142,11 @@ def test_reshape():
     # attempting invalid reshape
     with pytest.raises(ValueError, match="cannot reshape array"):
         arr1d.reshape((3,3))
-    
+
     # attempting reshape with a size 0 dimension
     with pytest.raises(ValueError, match="cannot reshape array"):
         arr1d.reshape((3,0))
-    
+
     arr2d = coo_array([[1, 2, 0], [0, 0, 3]])
     assert arr2d.shape == (2, 3)
 
@@ -284,7 +284,7 @@ def test_sum_duplicates():
     arr4d.sum_duplicates()
     assert arr4d.nnz == 2
     assert_equal(arr4d.toarray(), expected)
-    
+
     # when there are no duplicates
     arr_nodups = coo_array(([1, 2, 3, 4], ([0, 0, 1, 1], [0, 1, 0, 1])))
     assert arr_nodups.nnz == 4
@@ -446,7 +446,7 @@ def test_nd_tuple_constructor_with_shape(shape):
     res = coo_array(arr, shape=shape)
     assert res.shape == shape
     assert_equal(res.toarray(), arr)
-    
+
 
 def test_tuple_constructor_for_dim_size_zero():
     # arrays with a dimension of size 0
@@ -455,7 +455,7 @@ def test_tuple_constructor_for_dim_size_zero():
 
     empty_arr = coo_array(([], ([],[])), shape=(4,0))
     assert_equal(empty_arr.toarray(), np.empty((4,0)))
-    
+
 
 @pytest.mark.parametrize(('shape', 'new_shape'), [((4,9,6,5), (3,6,15,4)),
                                                   ((4,9,6,5), (36,30)),
@@ -520,7 +520,7 @@ def test_nd_eliminate_zeros():
     arr3d = coo_array(([1, 0, 0, 4], ([0, 1, 1, 2], [0, 1, 0, 1], [1, 1, 2, 0])))
     assert arr3d.nnz == 4
     assert arr3d.count_nonzero() == 2
-    assert_equal(arr3d.toarray(), np.array([[[0, 1, 0], [0, 0, 0]], 
+    assert_equal(arr3d.toarray(), np.array([[[0, 1, 0], [0, 0, 0]],
                                     [[0, 0, 0], [0, 0, 0]], [[0, 0, 0], [4, 0, 0]]]))
     arr3d.eliminate_zeros()
     assert arr3d.nnz == 2
@@ -561,7 +561,7 @@ def test_nd_add_sparse(shape):
     sp_x = random_array((shape), density=0.6, random_state=rng, dtype=int)
     sp_y = random_array((shape), density=0.6, random_state=rng, dtype=int)
     den_x, den_y = sp_x.toarray(), sp_y.toarray()
-    
+
     dense_sum = den_x + den_y
     sparse_sum = sp_x + sp_y
     assert_equal(dense_sum, sparse_sum.toarray())
@@ -579,9 +579,9 @@ def test_add_sparse_with_inf():
 @pytest.mark.parametrize(('a_shape', 'b_shape'), [((7,), (12,)),
                                                   ((6,4), (6,5)),
                                                   ((5,9,3,2), (9,5,2,3)),])
-def test_nd_add_sparse_with_inconsistent_shapes(a_shape, b_shape): 
+def test_nd_add_sparse_with_inconsistent_shapes(a_shape, b_shape):
     rng = np.random.default_rng(23409823)
-    
+
     arr_a = random_array((a_shape), density=0.6, random_state=rng, dtype=int)
     arr_b = random_array((b_shape), density=0.6, random_state=rng, dtype=int)
     with pytest.raises(ValueError, match="inconsistent shapes"):
@@ -609,7 +609,7 @@ def test_nd_sub_sparse(shape):
     sp_x = random_array(shape, density=0.6, random_state=rng, dtype=int)
     sp_y = random_array(shape, density=0.6, random_state=rng, dtype=int)
     den_x, den_y = sp_x.toarray(), sp_y.toarray()
-    
+
     dense_sum = den_x - den_y
     sparse_sum = sp_x - sp_y
     assert_equal(dense_sum, sparse_sum.toarray())
@@ -627,9 +627,9 @@ def test_nd_sub_sparse_with_nan():
 @pytest.mark.parametrize(('a_shape', 'b_shape'), [((7,), (12,)),
                                                   ((6,4), (6,5)),
                                                   ((5,9,3,2), (9,5,2,3)),])
-def test_nd_sub_sparse_with_inconsistent_shapes(a_shape, b_shape): 
+def test_nd_sub_sparse_with_inconsistent_shapes(a_shape, b_shape):
     rng = np.random.default_rng(23409823)
-    
+
     arr_a = random_array((a_shape), density=0.6, random_state=rng, dtype=int)
     arr_b = random_array((b_shape), density=0.6, random_state=rng, dtype=int)
     with pytest.raises(ValueError, match="inconsistent shapes"):
@@ -637,8 +637,8 @@ def test_nd_sub_sparse_with_inconsistent_shapes(a_shape, b_shape):
 
 
 mat_vec_shapes = [
-    ((2, 3, 4, 5), (5,)), 
-    ((0, 0), (0,)), 
+    ((2, 3, 4, 5), (5,)),
+    ((0, 0), (0,)),
     ((2, 3, 4, 7, 8), (8,)),
     ((4, 4, 2, 0), (0,)),
     ((6, 5, 3, 2, 4), (4, 1)),

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -73,13 +73,13 @@ class TestSparseUtils:
         assert_equal(sputils.isshape((-1, 2), nonneg=True),False)
         assert_equal(sputils.isshape((2, -1), nonneg=True),False)
 
-        assert_equal(sputils.isshape((1.5, 2), allowed_ndims=(1,2)), False)
-        assert_equal(sputils.isshape(([2], 2), allowed_ndims=(1,2)), False)
-        assert_equal(sputils.isshape((2, 2, -2), nonneg=True, allowed_ndims=(1,2)),
+        assert_equal(sputils.isshape((1.5, 2), allow_nd=(1, 2)), False)
+        assert_equal(sputils.isshape(([2], 2), allow_nd=(1, 2)), False)
+        assert_equal(sputils.isshape((2, 2, -2), nonneg=True, allow_nd=(1, 2)),
                      False)
-        assert_equal(sputils.isshape((2,), allowed_ndims=(1,2)), True)
-        assert_equal(sputils.isshape((2, 2,), allowed_ndims=(1,2)), True)
-        assert_equal(sputils.isshape((2, 2, 2), allowed_ndims=(1,2)), False)
+        assert_equal(sputils.isshape((2,), allow_nd=(1, 2)), True)
+        assert_equal(sputils.isshape((2, 2,), allow_nd=(1, 2)), True)
+        assert_equal(sputils.isshape((2, 2, 2), allow_nd=(1, 2)), False)
 
     def test_issequence(self):
         assert_equal(sputils.issequence((1,)), True)


### PR DESCRIPTION
This PR changes your PR to do two things:
- remove some spaces at the end of lines (first commit)
- change the handling of `allowed_ndims` to be stored in a class attribute rather than constructed each time it is used. This means we centralize the creation/setting of allowed_ndims. I think it reduces the amount of code handling this stuff too. Hopefully that will make it easier to maintain in the long run. I named the attribute `_allow_nd` to make it private and using an active verb instead of an adjective. I changed the kwarg in `_sputils.py` to `allow_nd` to match this attribute name.

If you merge this you will need to pull to your local copy before making further changes.
It's a little strange to have a PR on a PR, but it works. And I thought it was a big enough change to have your approval and/or comments rather than just pushing it to your branch.